### PR TITLE
Dozer Mapper와 log4j 이슈

### DIFF
--- a/sejongdeveloper/build.gradle
+++ b/sejongdeveloper/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	//Dozer
 	implementation 'com.github.dozermapper:dozer-core:6.5.2'
 
+	//log4j 취약점 이슈 해결
+	implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+	implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
+	implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.17.1'
 }
 
 tasks.named('test') {

--- a/sejongdeveloper/build.gradle
+++ b/sejongdeveloper/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	//Object Mapper 사용할 때 LocalDate 이슈 해결
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
 
+	//Dozer
+	implementation 'com.github.dozermapper:dozer-core:6.5.2'
+
 }
 
 tasks.named('test') {

--- a/sejongdeveloper/src/main/java/com/codesoom/sejongdeveloper/application/ReleaseOrderService.java
+++ b/sejongdeveloper/src/main/java/com/codesoom/sejongdeveloper/application/ReleaseOrderService.java
@@ -3,6 +3,8 @@ package com.codesoom.sejongdeveloper.application;
 import com.codesoom.sejongdeveloper.domain.ReleaseOrder;
 import com.codesoom.sejongdeveloper.dto.ReleaseOrderSaveRequest;
 import com.codesoom.sejongdeveloper.repository.ReleaseOrderRepository;
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ public class ReleaseOrderService {
 
     private final ReleaseOrderRepository releaseOrderRepository;
     private final ReleaseOrderDetailService releaseOrderDetailService;
+    private Mapper mapper = DozerBeanMapperBuilder.buildDefault();
 
     /**
      * 출고를 저장하고 저장된 출고의 일련번호를 리턴한다.
@@ -26,10 +29,7 @@ public class ReleaseOrderService {
      */
     @Transactional
     public Long saveReleaseOrder(ReleaseOrderSaveRequest source) {
-        ReleaseOrder releaseOrder = ReleaseOrder.builder()
-                .name(source.getName())
-                .date(source.getDate())
-                .build();
+        ReleaseOrder releaseOrder = mapper.map(source, ReleaseOrder.class);
 
         ReleaseOrder savedReleaseOrder = releaseOrderRepository.save(releaseOrder);
         releaseOrderDetailService.saveReleaseOrderDetails(savedReleaseOrder, source.getReleaseOrderDetails());

--- a/sejongdeveloper/src/main/java/com/codesoom/sejongdeveloper/dto/ReleaseOrderSaveRequest.java
+++ b/sejongdeveloper/src/main/java/com/codesoom/sejongdeveloper/dto/ReleaseOrderSaveRequest.java
@@ -1,5 +1,6 @@
 package com.codesoom.sejongdeveloper.dto;
 
+import com.github.dozermapper.core.Mapping;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,8 +15,10 @@ import java.util.List;
 public class ReleaseOrderSaveRequest {
 
     @NotBlank(message = "출고명을 입력하세요.")
+    @Mapping
     private String name;    //출고명
 
+    @Mapping
     private LocalDate date; //출고날짜
 
     @Size(min = 1, message = "출고상품이 존재하지 않습니다.")


### PR DESCRIPTION
[1] Dozer
Dozer 라이브러리는 유용하지만 제가 사용법을 잘 모르는 것일지도 몰라도 

엔티티 필드멤버에 다른 참조 엔티티가 있는 경우 사용할 수 없다는 단점이 있네요.

예: 
패키지 : dto
클래스 : ReleaseOrderDetailSaveRequest
필드멤버 : Long obtainOrderDetailId

패키지 : domain
클래스 : ReleaseOrderDetail
필드멤버 : ObtainOrderDetail obtainOrderDetail


[2] log4j
올해 발견된 log4j의 2.xx버전 취약점의 해결방안으로 최신버전으로 변경했습니다.